### PR TITLE
Avoid broken indentation after some -type annotations.

### DIFF
--- a/indent/erlang.vim
+++ b/indent/erlang.vim
@@ -32,6 +32,10 @@ function s:ErlangIndentAfterLine(l)
     let lastReceive = 0 " the last token was a 'receive'; needed for 'after'
     let lastHashMark = 0 " the last token was a 'hashmark'
 
+    " ignore type annotation lines
+    if a:l =~# '^\s*-type'
+	return 0
+
     while 0<= i && i < length
 
         " m: the next value of the i

--- a/indent/erlang.vim
+++ b/indent/erlang.vim
@@ -35,6 +35,7 @@ function s:ErlangIndentAfterLine(l)
     " ignore type annotation lines
     if a:l =~# '^\s*-type'
 	return 0
+    endif
 
     while 0<= i && i < length
 


### PR DESCRIPTION
Simple (fixed) fix to avoid broken indentation after -type annotations with fun() inside them. For example

```
-type fooer() :: fun((bar()) -> term()).
-spec foo(fooer()) -> term().
foo(Fun) -> ...
```

instead of

```
-type fooer() :: fun((bar()) -> term()).
    -spec foo(fooer()) -> term().
    foo(Fun) -> ...
```
