### PR TITLE
set sensible comments and commenstring

### DIFF
--- a/ftplugin/erlang.vim
+++ b/ftplugin/erlang.vim
@@ -39,6 +39,9 @@ function s:SetErlangOptions()
 		setlocal omnifunc=erlangcomplete#Complete
 	endif
 
+	setlocal comments=:%%%,:%%,:%
+	setlocal commentstring=%%s
+
 	setlocal foldmethod=expr
 	setlocal foldexpr=GetErlangFold(v:lnum)
 	setlocal foldtext=ErlangFoldText()


### PR DESCRIPTION
This (re-)enters commentstring and comments
settings for erlang.
The default erlang-ftplugin already sets these, but when
using vimerl those settings seem to be ignored.

Here are the original settings:
https://code.google.com/p/vim/source/browse/runtime/ftplugin/erlang.vim#43
